### PR TITLE
fix: rename fields config api endpoint

### DIFF
--- a/src/services/apiRoutes.ts
+++ b/src/services/apiRoutes.ts
@@ -1,5 +1,5 @@
 const ROUTES = {
-  GET_FIELDS_CONFIG: '/Fields',
+  GET_FIELDS_CONFIG: '/config',
   GET_LINKED_RECORDS: '/LinkedRecords',
   GET_NOTIFICATIONS: '/MatchesForReview',
   GET_PATIENT_DOCUMENT: '/Document',


### PR DESCRIPTION
## Motivation

The fields config endpoint has been rename to "GET /config" instead "GET /fields"