### PR TITLE
Fix: names of the env vars should start with REACT_APP

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,6 +1,6 @@
 REACT_APP_JEMPI_BASE_URL=http://localhost:50000/JeMPI
 REACT_APP_MOCK_BACKEND=false
 
-KC_FRONTEND_URL=http://localhost:9088
-KC_REALM_NAME=platform-realm
-KC_JEMPI_CLIENT_ID=jempi-oauth
+REACT_APP_KC_FRONTEND_URL=http://localhost:9088
+REACT_APP_KC_REALM_NAME=platform-realm
+REACT_APP_KC_JEMPI_CLIENT_ID=jempi-oauth

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ export const config = {
   apiUrl:
     process.env.REACT_APP_JEMPI_BASE_URL || 'http://localhost:50000/JeMPI',
   shouldMockBackend: process.env.REACT_APP_MOCK_BACKEND === 'true',
-  KeyCloakUrl: process.env.KC_FRONTEND_URL || 'http://localhost:9088',
-  KeyCloakRealm: process.env.KC_REALM_NAME || 'platform-realm',
-  KeyCloakClientId: process.env.KC_JEMPI_CLIENT_ID || 'jempi-oauth'
+  KeyCloakUrl: process.env.REACT_APP_KC_FRONTEND_URL || 'http://localhost:9088',
+  KeyCloakRealm: process.env.REACT_APP_KC_REALM_NAME || 'platform-realm',
+  KeyCloakClientId: process.env.REACT_APP_KC_JEMPI_CLIENT_ID || 'jempi-oauth'
 }


### PR DESCRIPTION
Motivation: 
Names of the env vars should start with REACT_APP
This will fix the issue with vars passed via compose file